### PR TITLE
Fix Compressing Assets

### DIFF
--- a/ActiveFormAsset.php
+++ b/ActiveFormAsset.php
@@ -9,18 +9,25 @@
 
 namespace kartik\form;
 
+use yii\web\AssetBundle;
+
 /**
  * Asset bundle for ActiveForm Widget
  *
  * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @since 1.0
  */
-class ActiveFormAsset extends \kartik\base\AssetBundle
+class ActiveFormAsset extends AssetBundle
 {
-    public function init()
-    {
-        $this->setSourcePath(__DIR__ . '/assets');
-        $this->setupAssets('css', ['css/activeform']);
-        parent::init();
-    }
+    public $sourcePath = '@vendor/kartik-v/yii2-widget-activeform/assets';
+
+    public $css = [
+        'css/activeform.css'
+    ];
+
+    public $depends = [
+        'yii\web\JqueryAsset',
+        'yii\web\YiiAsset',
+        'yii\bootstrap\BootstrapAsset',
+    ];
 }


### PR DESCRIPTION
css/activeform.css, after compression is still displayed in the header as a separate file

https://github.com/yiisoft/yii2/blob/786e4c64e3a5aa3a1fd2cc66fc5bd716ee2010ec/docs/guide/structure-assets.md#combining-and-compressing-assets-

```yii asset assets.php config/assets-prod.php``` 
сompressing css/activeform.css and append to all-{hash}.css
create config for kartik\form\ActiveFormAsset class
```php
return [
    'components' => [
        'assetManager' => [
            'bundles' => [
                'kartik\\form\\ActiveFormAsset' => [
                    'sourcePath' => null,
                    'js' => [],
                    'css' => [],
                    'depends' => [
                        'yii\\web\\JqueryAsset',
                        'yii\\web\\YiiAsset',
                        'yii\\bootstrap\\BootstrapAsset',
                       'all',
                    ],
                ],
            ],
        ],
    ],
],
```
but when calling the init() method, these values are overwritten, css and js files as before present the content.