### PR TITLE
control-label class for Vertical forms

### DIFF
--- a/ActiveField.php
+++ b/ActiveField.php
@@ -129,7 +129,7 @@ class ActiveField extends \yii\widgets\ActiveField
         } elseif (!isset($this->autoPlaceholder)) {
             $this->autoPlaceholder = false;
         }
-        if ($this->form->type === ActiveForm::TYPE_HORIZONTAL) {
+        if ($this->form->type === ActiveForm::TYPE_HORIZONTAL || $this->form->type === ActiveForm::TYPE_VERTICAL) {
             Html::addCssClass($this->labelOptions, 'control-label');
         }
         if ($this->showLabels === ActiveForm::SCREEN_READER) {


### PR DESCRIPTION
For Vertical forms, Labels are not colored with green (success) or red (error) css styles since <label> tags do not have control-label class when using labelOptions in field() function. Without 'labelOptions' everything is working. 
Example:
$form->field(
            $model, 
            "attribute", 
            [
                    'labelOptions' => [
                        'label' => $productPercentage->product->product_name
                    ]
                ]
            )->textInput() 

I'm not sure if this is the correct place for fix. But it resolves my problem.