### PR TITLE
fix of issue #75 and enh #76 (dynamic formConfig and comp. to Yii/bootstrap/ActiveForm

### DIFF
--- a/ActiveField.php
+++ b/ActiveField.php
@@ -4,7 +4,28 @@
  * @copyright  Copyright &copy; Kartik Visweswaran, Krajee.com, 2015 - 2016
  * @package    yii2-widgets
  * @subpackage yii2-widget-activeform
- * @version    1.4.8
+ * @version    1.4.9a
+ * 
+ * Changes version 1.4.9a by Enrica
+ * - set default template moved from ActiveForm to ActiveField.initLayout()
+ *   (template and css are properties of an ActiveField)
+ * - Enhance public options 'labelSpan' and 'deviceSize' on level ActiveField also
+ * - Defaulting of 'labelSpan' and 'deviceSize' Prio: 1. Option (fieldConfig), 
+ *    2. formConfig, 3. _settings (default)
+ * - Build CSS for label, offset and Input on level field
+ * 
+ * Changes version 1.4.9b by Enrica
+ * - bug: checkbox/radio showLabels=>false didn't work
+ * - bug: Hint bedside container 'table' doesn't work (why?), fix use 'form'
+ * - enh: new option 'horizontalCss' compatible with Yii/bootstrap/ActiveForm rsp. Field
+ *        Options 'wrapper', 'label', 'error', 'hint'. These options give complete control
+ *        for all classes. 'labelSpan' still works and 'wrapper' is added if there
+ *        is no 'col-' tag defined.
+ * - enh: add template with '{beginWrapper'}, '{endWrapper}' to enclose input, hint, error
+ * - enh: optionally template '{label}' could be splitted in '{beginLabel}', 
+ *        '{labelTitle}' and '{endLabel}' tag. '{label}' is still working as usual
+ * 
+ * 
  */
 
 namespace kartik\form;
@@ -16,7 +37,7 @@ use yii\helpers\Inflector;
 /**
  * Extends the ActiveField component to handle various bootstrap form types and handle input groups.
  *
- * Example(s):
+ * Example(s) with addons:
  * ```php
  *    echo $this->form->field($model, 'email', ['addon' => ['type'=>'prepend', 'content'=>'@']]);
  *    echo $this->form->field($model, 'amount_paid', ['addon' => ['type'=>'append', 'content'=>'.00']]);
@@ -24,6 +45,14 @@ use yii\helpers\Inflector;
  *     glyphicon-phone']]);
  * ```
  *
+ * Example(s) with CSS control:
+ * ```php
+ *    echo $this->form->field($model, 'email', ['labelSpan' => 2, 'deviceSize' => ActiveForm::SIZE_SMALL]]);
+ *    echo $this->form->field($model, 'amount_paid', ['horizontalCssClass' => ['wrapper' => 'hidden-xs']]);
+ *    echo $this->form->field($model, 'phone', ['horizontalCssClass' => ['label' => 'col-md-2 col-sm-3 col-xs-12 myRedClass']]);
+ *    echo $this->form->field($model, 'special', ['template' => '{beginLabel}Text for: {labelTitle}{endLabel}\n{beginWrapper}\n{input}\n{hint}\n{error}\n{endWrapper}']); 
+ * ```
+ * 
  * @property ActiveForm $form
  *
  * @author Kartik Visweswaran <kartikv2@gmail.com>
@@ -31,6 +60,7 @@ use yii\helpers\Inflector;
  */
 class ActiveField extends \yii\widgets\ActiveField
 {
+    const NOT_SET = '';
     const TYPE_RADIO = 'radio';
     const TYPE_CHECKBOX = 'checkbox';
     const STYLE_INLINE = 'inline';
@@ -229,6 +259,8 @@ class ActiveField extends \yii\widgets\ActiveField
         'hint' => '{hint}',
         'showLabels' => true,
         'showErrors' => true,
+        'labelSpan' => ActiveForm::DEFAULT_LABEL_SPAN,
+        'deviceSize' => ActiveForm::SIZE_MEDIUM,
     ];
     /**
      * @var bool whether there is a feedback icon configuration set
@@ -238,6 +270,70 @@ class ActiveField extends \yii\widgets\ActiveField
      * @var bool whether there is a feedback icon configuration set
      */
     protected $_isHintSpecial = false;
+    
+    // new vars from Enrica for v 1.4.9a
+    
+    /**
+     *
+     * @var type string: inherits and overrides values from parent class
+     * Value can be overridden by option in ActiveForm.field call.
+     * Following tags supported:
+     * {beginLabel}: Container begin tag for labels
+     * {labelTitle}: Label content without tags
+     * {endLabel}: Container end tag for labels
+     * {label}: Full label tag with begin tag, content and end tag
+     * {beginWrapper}: Div container for input,error and hint start tag
+     * {input}: placeholder for input control whatever it is
+     * {hint}: placeholder for hint/help text including sub container
+     * {error}: placeholder for error text including sub container
+     * {endWrapper}: end tag for {beginWrapper} normally '</div>'
+     */  
+    public $template = "{label}\n{beginWrapper}\n{input}\n{hint}\n{error}\n{endWrapper}";  
+    
+    /**
+     *
+     * @var type int labelSpan: int, the bootstrap grid column width (usually between 1 to 12)
+     */
+    public $labelSpan;
+
+    /**
+     *
+     * @var type deviceSize: string, one of the bootstrap sizes (refer the ActiveForm::SIZE constants)
+     */
+    public $deviceSize;
+
+    /**
+     * @var string the label additional css class for horizontal forms and special inputs like checkbox and radio.
+     */
+    private $_labelCss;
+
+    /**
+     * @var string the input container additional css class for horizontal forms and special inputs like checkbox and
+     *     radio.
+     */
+    private $_inputCss;
+
+    /**
+     * @var string the offset class for error and hint for horizontal forms
+     * or for special inputs like checkbox and radio.
+     */
+    private $_offsetCss;
+
+    // new vars Enrica 1.4.9b (Compat with yii/bootstrap widget
+    
+     /**
+     * @var null|array CSS grid classes for horizontal layout. This must be an array with these keys:
+     *  - 'offset' the offset grid class to append to the wrapper if no label is rendered
+     *  - 'label' the label grid class
+     *  - 'wrapper' the wrapper grid class
+     *  - 'error' the error grid class
+     *  - 'hint' the hint grid class
+     * These options are compatible with Yii/bootstrap/ActiveForm and provide a complete
+     * flexible container.
+     * If 'labelSpan' (eg. in formConfig) is set and 'wrapper' is set both css options are
+     * concatenated. If 'wrapper' contains a 'col-' class wrapper overrides tag from 'labelSpan'
+     */
+    public $horizontalCssClasses;
 
     /**
      * Parses and returns addon content
@@ -405,6 +501,10 @@ class ActiveField extends \yii\widgets\ActiveField
                 );
             }
         }
+        if (strpos($this->template, '{beginLabel}') !== false){
+            $this->renderLabelParts($label, $options);
+        }
+        
         return parent::label($label, $options);
     }
 
@@ -703,6 +803,12 @@ class ActiveField extends \yii\widgets\ActiveField
         if ($enclosedByLabel) {
             $this->_offset = true;
             $this->parts['{label}'] = '';
+            // Enrica: fix showLables => false bug fix
+            $showLabels = $this->hasLabels();
+            if ($showLabels === false){
+                $options['label'] = '';
+                $this->showLabels = true;
+            }
         } else {
             $this->_offset = false;
             if (isset($options['label']) && !isset($this->parts['{label}'])) {
@@ -786,8 +892,9 @@ class ActiveField extends \yii\widgets\ActiveField
         if ($showLabels === ActiveForm::SCREEN_READER) {
             Html::addCssClass($this->labelOptions, ActiveForm::SCREEN_READER);
         }
+        $this->initCssWrappers();   // new Enrica 1.4.9b
         $this->initLabels();
-        $this->initLayout();
+//        $this->initLayout();  deleted Enrica 1.4.9b -> functionality is done later again in buildTemplate
         $this->initHints();
         $this->_hasFeedback = !empty($this->feedbackIcon) && is_array($this->feedbackIcon);
     }
@@ -797,7 +904,8 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     protected function initLabels()
     {
-        $labelCss = $this->form->getLabelCss();
+        //$labelCss = $this->form->getLabelCss();  Replaced by Enrica 1.4.9a
+        $labelCss = $this->_labelCss;
         if ($this->hasLabels() === ActiveForm::SCREEN_READER) {
             Html::addCssClass($this->labelOptions, ActiveForm::SCREEN_READER);
         } elseif ($labelCss != ActiveForm::NOT_SET) {
@@ -812,13 +920,105 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     protected function hasLabels()
     {
-        $showLabels = $this->getConfigParam('showLabels');
+        $showLabels = $this->getConfigParam('showLabels'); // plus abfrage $this-showLabels kombinieren.
         if ($this->autoPlaceholder && $showLabels !== ActiveForm::SCREEN_READER) {
             $showLabels = false;
         }
         return $showLabels;
     }
 
+    /**
+     * Prepares bootstrap grid col classes for label and input tags and initiate
+     * private CSS variables. 
+     * no return
+     * Process order for 'labelSpan' and 'wrapper'
+     * 
+     * 1. use a) $labelSpan/$deviceSize b) formConfig(['labelSpan' => x, 'deviceSize' => xy]) and build css tag.
+     * 2a. if horizontalCssClass['wrapper'] isset and no 'col-' tag then add this to css tag from 1)
+     * 2b. if horizontalCssClass['wrapper'] isset and has 'col-' tag then override css tag completely
+     * 3. if no $labelSpan and no horizontalCssClass['wrapper'] isset then use default from _settings
+     * Same behaviour with horizontalCssClass['label']
+     * 
+     */
+    protected function initCssWrappers() {
+        /* new 1.4.9a Enrica: Css init move CSS control from ActiveForm to 
+         * ActiveField
+        */        
+        
+        // prepare labelSpan without defaulting
+        if (!empty($this->labelSpan)){
+            $span = $this->labelSpan;
+        } elseif (isset($this->form->formConfig['labelSpan'])){
+            $span = $this->form->formConfig['labelSpan'];
+        }
+        
+        // check horizontalCssClasses['wrapper'] if there is a col- class
+        if (isset($this->horizontalCssClasses['wrapper'])){
+            if (strpos($this->horizontalCssClasses['wrapper'], 'col-') !== false){
+                $span = '';
+            }
+        }
+        
+        if (empty($span) && !isset($this->horizontalCssClasses['wrapper'])){
+            $span = $this->_settings['labelSpan'];
+        }
+        
+        if (!empty($this->deviceSize)){
+            $size = $this->deviceSize;
+        } elseif (isset($this->form->formConfig['deviceSize'])){
+            $size = $this->form->formConfig['deviceSize'];
+        } else {
+            $size = $this->_settings['deviceSize'];
+        }
+        $this->deviceSize = $size;
+        
+        $labelCss = $inputCss = $offsetCss = self::NOT_SET;
+
+        if ($span != self::NOT_SET && intval($span) > 0) {
+            $span = intval($span);
+
+            /* Validate if invalid labelSpan is passed - else set to DEFAULT_LABEL_SPAN */
+            if ($span <= 0 && $span >= $this->form->fullSpan) {
+                $span = $this->form->fullSpan;
+            }
+
+            /* Validate if invalid deviceSize is passed - else default to medium */
+            // Enrica 1.4.9a: add check valid values
+            if ($size == self::NOT_SET || !in_array($size, [ActiveForm::SIZE_TINY,
+                ActiveForm::SIZE_SMALL, ActiveForm::SIZE_MEDIUM, ActiveForm::SIZE_LARGE])) {
+                    $size = ActiveForm::SIZE_MEDIUM;
+            }
+
+            $this->labelSpan = $span;
+            
+            $prefix = "col-{$size}-";
+            $this->_labelCss = $prefix . $span;
+            $this->_inputCss = $prefix . ($this->form->fullSpan - $span);
+            $this->_offsetCss = "col-" . $size . "-offset-" . $span;
+        }
+        
+        if (isset($this->horizontalCssClasses['wrapper'])){
+            if ($span !== self::NOT_SET){
+                $this->_inputCss .= " ";
+            }
+            $this->_inputCss .= $this->horizontalCssClasses['wrapper'];
+        }
+        
+        if (isset($this->horizontalCssClasses['offset'])){
+            $this->_offsetCss = $this->horizontalCssClasses['offset'];
+        }
+        
+        if (isset($this->horizontalCssClasses['label'])){
+            if ($span !== self::NOT_SET){
+                $this->_labelCss .= " ";
+            }
+            $this->_labelCss .= $this->horizontalCssClasses['label'];
+        }
+        
+        if (isset($this->horizontalCssClasses['error'])){
+            $this->errorOptions['class'] = $this->errorOptions['class'] . " " . $this->horizontalCssClasses['error'];
+        }
+    }
     /**
      * Initialize layout settings for label, input, error and hint blocks and for various bootstrap 3 form layouts
      */
@@ -855,24 +1055,32 @@ class ActiveField extends \yii\widgets\ActiveField
         }
         if ($this->skipFormLayout) {
             $this->mergeSettings($showLabels, $showErrors);
+            $this->parts['{beginWrapper}'] = '';
+            $this->parts['{endWrapper}'] = '';
+            $this->parts['{beginLabel}'] = '';
+            $this->parts['{labelTitle}'] = '';
+            $this->parts['{endLabel}'] = '';
             return;
         }
         $inputDivClass = '';
-        $errorDivClass = '';
-        if ($this->form->hasInputCss()) {
-            $offsetDivClass = $this->form->getOffsetCss();
-            $inputDivClass = ($this->_offset) ? $offsetDivClass : $this->form->getInputCss();
+    //    $errorDivClass = '';
+        if (!empty($this->_inputCss)) {
+            $offsetDivClass = $this->_offsetCss . " " . $this->_inputCss;
+            $inputDivClass = ($this->_offset) ? $offsetDivClass : $this->_inputCss;
             if ($showLabels === false || $showLabels === ActiveForm::SCREEN_READER) {
-                $size = ArrayHelper::getValue($this->form->formConfig, 'deviceSize', ActiveForm::SIZE_MEDIUM);
-                $errorDivClass = "col-{$size}-{$this->form->fullSpan}";
-                $inputDivClass = $errorDivClass;
-            } elseif ($this->form->hasOffsetCss()) {
-                $errorDivClass = $offsetDivClass;
+            //    $size = ArrayHelper::getValue($this->form->formConfig, 'deviceSize', ActiveForm::SIZE_MEDIUM);
+            //    $errorDivClass = "col-{$this->deviceSize}-{$this->form->fullSpan}";
+                $inputDivClass = "col-{$this->deviceSize}-{$this->form->fullSpan}";
+            } elseif (!empty($this->_offsetCss)) {
+            //    $errorDivClass = $offsetDivClass;
             }
         }
-        $this->setLayoutContainer('input', $inputDivClass);
-        $this->setLayoutContainer('error', $errorDivClass, $showErrors);
-        $this->setLayoutContainer('hint', $errorDivClass);
+        //$this->setLayoutContainer('input', $inputDivClass);
+        //$this->setLayoutContainer('error', $errorDivClass, $showErrors);
+        //$this->setLayoutContainer('hint', $errorDivClass);
+//        $tag = ArrayHelper::remove($options, 'tag', 'div');
+    $this->parts['{beginWrapper}'] = Html::beginTag('div', ['class' => $inputDivClass]);
+        $this->parts['{endWrapper}'] = Html::endTag('div');
         $this->mergeSettings($showLabels, $showErrors);
     }
 
@@ -898,12 +1106,13 @@ class ActiveField extends \yii\widgets\ActiveField
         if ($this->hintType !== self::HINT_SPECIAL) {
             return;
         }
-        $container = ArrayHelper::getValue($this->hintSettings, 'iconBesideInput') ?  'table' : 'form';
+        $container = ArrayHelper::getValue($this->hintSettings, 'iconBesideInput') ?  'form' : 'form';
         $this->hintSettings = array_replace_recursive([
             'showIcon' => true,
             'iconBesideInput' => false,
             'labelTemplate' => '{label}{help}',
-            'inputTemplate' => '<table style="width:100%"><tr><td>{input}</td><td style="width:5%">{help}</td></tr></table>',
+        //    'inputTemplate' => '<table style="width:100%"><tr><td>{input}</td><td style="width:5%">{help}</td></tr></table>',
+            'inputTemplate' => '<div style="width:90%; float:left">{input}</div><div style="padding-top:7px">{help}</div>',
             'onLabelClick' => false,
             'onLabelHover' => true,
             'onIconClick' => true,
@@ -997,7 +1206,7 @@ class ActiveField extends \yii\widgets\ActiveField
             $showErrors = false;
         }
         $showLabels = $showLabels && $this->hasLabels();
-        $this->buildLayoutParts($showLabels, $showErrors);
+        $this->buildLayoutParts($showLabels, $showErrors);   //ist überflüssig, da bereits bei init erfolgt
         extract($this->_settings);
         if (!empty($this->_multiselect)) {
             $input = str_replace('{input}', $this->_multiselect, $input);
@@ -1009,10 +1218,14 @@ class ActiveField extends \yii\widgets\ActiveField
         $newInput = $this->contentBeforeInput . $this->generateAddon() . $this->renderFeedbackIcon() . $this->contentAfterInput;
         $newError = "{$this->contentBeforeError}{error}{$this->contentAfterError}";
         $this->template = strtr($this->template, [
+           '{beginLabel}' => $showLabels ? '{beginLabel}' : "",
+           '{endLabel}' => $showLabels ? '{endLabel}': "",
            '{label}' => $showLabels ? "{$this->contentBeforeLabel}{label}{$this->contentAfterLabel}" : "",
+           '{labelTitel}' => $showLabels ? "{$this->contentBeforeLabel}{labelTitel}{$this->contentAfterLabel}" : "",
            '{input}' => str_replace('{input}', $newInput, $input),
            '{error}' => $showErrors ? str_replace('{error}', $newError, $error) : '',
        ]);
+       
     }
 
     /**
@@ -1056,7 +1269,32 @@ class ActiveField extends \yii\widgets\ActiveField
         $this->getFeedbackIcon($config, 'success', $type, $prefix, $id) .
         $this->getFeedbackIcon($config, 'error', $type, $prefix, $id);
     }
-
+    
+    /**
+     * @param string|null $label the label or null to use model label
+     * @param array $options the tag options
+     */
+    protected function renderLabelParts($label = null, $options = [])
+    {
+        $options = array_merge($this->labelOptions, $options);
+        if ($label === null) {
+            if (isset($options['label'])) {
+                $label = $options['label'];
+                unset($options['label']);
+            } else {
+                $attribute = Html::getAttributeName($this->attribute);
+                $label = Html::encode($this->model->getAttributeLabel($attribute));
+            }
+        }
+        if (!isset($options['for'])) {
+            $options['for'] = Html::getInputId($this->model, $this->attribute);
+        }
+        $this->parts['{beginLabel}'] = Html::beginTag('label', $options);
+        $this->parts['{endLabel}'] = Html::endTag('label');
+        if (!isset($this->parts['{labelTitle}'])) {
+            $this->parts['{labelTitle}'] = $label;
+        }
+    }
     /**
      * Generates a feedback icon
      *

--- a/ActiveField.php
+++ b/ActiveField.php
@@ -302,6 +302,18 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public $deviceSize;
 
+     /**
+     * @var boolean whether to render the error. Default is `true` except for layout `inline`.
+     * For compatibility with Yii/bootstrap/ActiveField; is handed over to $showErrors 
+     */
+    public $enableError;
+    /**
+     * @var boolean whether to render the label. Default is `true`.
+     * For compatibility with Yii/bootstrap/ActiveField; is handed over to $showLabels 
+     */
+
+    public $enableLabel;
+
     /**
      * @var string the label additional css class for horizontal forms and special inputs like checkbox and radio.
      */
@@ -879,6 +891,12 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     protected function initActiveField()
     {
+        if (isset($this->enableError)){
+            $this->showErrors = $this->enableError;
+        }
+        if (isset($this->enableLabel)){
+            $this->showLabels = $this->enableLabel;
+        }
         $showLabels = $this->getConfigParam('showLabels');
         $this->_isHintSpecial = $this->hintType === self::HINT_SPECIAL;
         if ($this->form->type === ActiveForm::TYPE_INLINE && !isset($this->autoPlaceholder) && $showLabels !== true) {

--- a/ActiveForm.php
+++ b/ActiveForm.php
@@ -4,7 +4,14 @@
  * @copyright  Copyright &copy; Kartik Visweswaran, Krajee.com, 2015 - 2016
  * @package    yii2-widgets
  * @subpackage yii2-widget-activeform
- * @version    1.4.8
+ * @version    1.4.9a
+ * 
+ * changes 1.4.9a: 
+ * - dynamic change of parameter 'formConfig and move 'getFormLayoutStyle' to ActiveField
+ * - fix issue #75 (closure as fieldConfig)
+ * 
+ * changes 1.4.9b:
+ * 
  */
 
 namespace kartik\form;
@@ -61,9 +68,26 @@ class ActiveForm extends \yii\widgets\ActiveForm
     const SCREEN_READER = 'sr-only';
 
     /**
-     * @var string form orientation type (for bootstrap styling). Defaults to 'vertical'.
+     * @var string the default field class name when calling [[field()]] to create a new field.
+     * @see fieldConfig
+     * add default fieldClass for fix of #75
+     */
+    public $fieldClass = 'kartik\form\ActiveField';
+
+
+    /**
+     * @var string form orientation type (for bootstrap styling). Either
+     * 'vertical', 'horizontal' or 'vertical'. For compatibility with Yii bootstrap
+     * ActiveForm widget 'default' means 'vertical'.
+     * Defaults to 'vertical'.
      */
     public $type;
+    
+    /**
+     *
+     * @var type string synonym for '$type' for Comp. with Yii bootstrap.
+     */
+    public $layout;
 
     /**
      * @var int set the bootstrap grid width. Defaults to [[ActiveForm::FULL_SPAN]].
@@ -91,7 +115,13 @@ class ActiveForm extends \yii\widgets\ActiveForm
      * ```
      */
     public $formConfig = [];
-
+ 
+    /**
+     * @var array HTML attributes for the form tag. Default is `['role' => 'form']`.
+     * new from Enrica 1.4.9a
+     */
+    public $options = ['role' => 'form'];
+ 
     /**
      * @var boolean whether all data in form are to be static inputs
      */
@@ -129,22 +159,22 @@ class ActiveForm extends \yii\widgets\ActiveForm
      */
     private $_config = [
         self::TYPE_VERTICAL => [
-            'labelSpan' => self::NOT_SET, // must be between 1 and 12
-            'deviceSize' => self::NOT_SET, // must be one of the SIZE modifiers
+    //        'labelSpan' => self::NOT_SET, // must be between 1 and 12
+    //        'deviceSize' => self::NOT_SET, // must be one of the SIZE modifiers
             'showLabels' => true, // show or hide labels (mainly useful for inline type form)
             'showErrors' => true, // show or hide errors (mainly useful for inline type form)
             'showHints' => true  // show or hide hints below the input
         ],
         self::TYPE_HORIZONTAL => [
-            'labelSpan' => self::DEFAULT_LABEL_SPAN,
-            'deviceSize' => self::SIZE_MEDIUM,
+    //        'labelSpan' => self::DEFAULT_LABEL_SPAN,
+    //        'deviceSize' => self::SIZE_MEDIUM,
             'showLabels' => true,
             'showErrors' => true,
             'showHints' => true,
         ],
         self::TYPE_INLINE => [
-            'labelSpan' => self::NOT_SET,
-            'deviceSize' => self::NOT_SET,
+    //        'labelSpan' => self::NOT_SET,
+    //        'deviceSize' => self::NOT_SET,
             'showLabels' => self::SCREEN_READER,
             'showErrors' => false,
             'showHints' => true,
@@ -157,15 +187,32 @@ class ActiveForm extends \yii\widgets\ActiveForm
      */
     protected function initForm()
     {
+        // Enrica: 1.4.9b
+        if (!isset($this->type) && isset($this->layout)){
+            $this->type = $this->layout;
+        }
+        if ($this->type === 'default'){
+            $this->type = self::TYPE_VERTICAL;
+        }
+        // end Enrica 1.4.9b
         if (!isset($this->type) || strlen($this->type) == 0) {
             $this->type = self::TYPE_VERTICAL;
         }
+        //Enrica new 1.4.9a
+        if (!in_array($this->type, [self::TYPE_VERTICAL, self::TYPE_HORIZONTAL, self::TYPE_INLINE])) {
+            throw new InvalidConfigException('Invalid layout type: ' . $this->type);
+        }
+        // end Enrica
+
         $this->formConfig = array_replace_recursive($this->_config[$this->type], $this->formConfig);
+
+        /* Enrica: Remove for fix #75
         if (!isset($this->fieldConfig['class'])) {
             $this->fieldConfig['class'] = ActiveField::className();
         }
-        $this->_inputCss = self::NOT_SET;
-        $this->_offsetCss = self::NOT_SET;
+        */
+    //    $this->_inputCss = self::NOT_SET;
+    //    $this->_offsetCss = self::NOT_SET;
         $class = 'form-' . $this->type;
         /* Fixes the button alignment for inline forms containing error block */
         if ($this->type === self::TYPE_INLINE && $this->formConfig['showErrors']) {
@@ -188,23 +235,21 @@ class ActiveForm extends \yii\widgets\ActiveForm
             throw new InvalidConfigException("The 'fullSpan' property must be a valid positive integer.");
         }
         $this->initForm();
-        $config = $this->formConfig;
-        $span = $config['labelSpan'];
-        $size = $config['deviceSize'];
-        $formStyle = $this->getFormLayoutStyle();
-        $this->_labelCss = $formStyle['labelCss'];
-        $this->_inputCss = $formStyle['inputCss'];
-        $this->_offsetCss = $formStyle['offsetCss'];
-
+    //    $config = $this->formConfig;
+    //    $span = $config['labelSpan']; Enrica is done in getFormLayoutStyle already
+    //    $size = $config['deviceSize'];
+    //    $formStyle = $this->getFormLayoutStyle();
+    //    $this->_labelCss = $formStyle['labelCss'];
+    //    $this->_inputCss = $formStyle['inputCss'];
+    //    $this->_offsetCss = $formStyle['offsetCss'];
+    /**    
         if ($span != self::NOT_SET && intval($span) > 0) {
             $span = intval($span);
 
-            /* Validate if invalid labelSpan is passed - else set to DEFAULT_LABEL_SPAN */
             if ($span <= 0 && $span >= $this->fullSpan) {
                 $span = self::DEFAULT_LABEL_SPAN;
             }
 
-            /* Validate if invalid deviceSize is passed - else default to medium */
             if ($size == self::NOT_SET) {
                 $size = self::SIZE_MEDIUM;
             }
@@ -214,15 +259,19 @@ class ActiveForm extends \yii\widgets\ActiveForm
             $this->_inputCss = $prefix . ($this->fullSpan - $span);
             $this->_offsetCss = "col-" . $size . "-offset-" . $span . " " . $this->_inputCss;
         }
-
+    */
+    /*  Enrica 1.4.9a: moved to ActiveField    
         if ($this->_inputCss == self::NOT_SET && empty($this->fieldConfig['template'])) {
             $this->fieldConfig['template'] = "{label}\n{input}\n{hint}\n{error}";
         }
+     
+     */
 
         parent::init();
         $this->registerAssets();
     }
 
+    /* moved to ActiveField::initCssWrappers
     public function getFormLayoutStyle()
     {
         $config = $this->formConfig;
@@ -233,13 +282,13 @@ class ActiveForm extends \yii\widgets\ActiveForm
         if ($span != self::NOT_SET && intval($span) > 0) {
             $span = intval($span);
 
-            /* Validate if invalid labelSpan is passed - else set to DEFAULT_LABEL_SPAN */
             if ($span <= 0 && $span >= $this->fullSpan) {
                 $span = self::DEFAULT_LABEL_SPAN;
             }
 
-            /* Validate if invalid deviceSize is passed - else default to medium */
-            if ($size == self::NOT_SET) {
+            // Enrica 1.4.9a: add check valid values
+            if ($size == self::NOT_SET || !in_array($size, [self::SIZE_TINY,
+                    self::SIZE_SMALL, self::SIZE_MEDIUM, self::SIZE_LARGE])) {
                 $size = self::SIZE_MEDIUM;
             }
 
@@ -249,18 +298,21 @@ class ActiveForm extends \yii\widgets\ActiveForm
             $offsetCss = "col-" . $size . "-offset-" . $span . " " . $inputCss;
         }
         return ['labelCss' => $labelCss, 'inputCss' => $inputCss, 'offsetCss' => $offsetCss];
-    }
+    } */
 
     /**
      * Gets label css property
      *
      * @return string
-     */
+     
     public function getLabelCss()
     {
-        return $this->_labelCss;
+        // Enrica change 1.4.9a: dynamic rebuild also after init
+        //return $this->_labelCss;
+        $formStyle = $this->getFormLayoutStyle();
+        return $formStyle['labelCss'];
     }
-
+*/
     /**
      * Sets label css property
      *
@@ -268,19 +320,21 @@ class ActiveForm extends \yii\widgets\ActiveForm
      */
     public function setLabelCss($class)
     {
-        $this->_labelCss = $class;
+       // $this->_labelCss = $class;
+        $this->fieldConfig['horizontalCssClass']['label'] = $class;
     }
+    
 
     /**
      * Gets input css property
      *
      * @return string
-     */
+     
     public function getInputCss()
     {
         return $this->_inputCss;
     }
-
+*/
     /**
      * Sets input css property
      *
@@ -288,29 +342,30 @@ class ActiveForm extends \yii\widgets\ActiveForm
      */
     public function setInputCss($class)
     {
-        $this->_inputCss = $class;
+        // $this->_inputCss = $class; Enrica: moved to ActiveField
+        $this->fieldConfig['horizontalCssClass']['wrapper'] = $class;
     }
 
     /**
      * Checks if input css property is set
      *
      * @return bool
-     */
+     
     public function hasInputCss()
     {
         return ($this->_inputCss != self::NOT_SET);
     }
-
+*/
     /**
      * Gets offset css property
      *
      * @return string
-     */
+    
     public function getOffsetCss()
     {
         return $this->_offsetCss;
     }
-
+*/
     /**
      * Sets offset css property
      *
@@ -318,7 +373,8 @@ class ActiveForm extends \yii\widgets\ActiveForm
      */
     public function setOffsetCss($class)
     {
-        $this->_offsetCss = $class;
+        //$this->_offsetCss = $class;
+        $this->fieldConfig['horizontalCssClass']['offset'] = $class;
     }
 
     /**

--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,12 @@
 Change Log: `yii2-widget-activeform`
 ====================================
 
+## Version 1.4.9
+- (bug #75): Closure function as fieldConfig now possible as Yii/widget supports
+- (enh #76): 'formConfig' can be changed between ActiveForm::begin / end and it has dynamic effect until rechanged.
+- (enh #76): Make ActiveForm/ActiveField compatibel to Yii/bootstrap with 'horizontalCssClasses' and wrappers
+- (bug #77): 'IconBeside' with container 'table' doesn't work, fix change container to 'form' and replace table by divs
+
 ## Version 1.4.8
 
 **Date:** 28-Apr-2016

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to the ```require``` section of your `composer.json` file.
 
 ## Latest Release
 
-> NOTE: The latest version of the module is v1.4.8. Refer the [CHANGE LOG](https://github.com/kartik-v/yii2-widget-activeform/blob/master/CHANGE.md) for details.
+> NOTE: The latest version of the module is v1.4.9. Refer the [CHANGE LOG](https://github.com/kartik-v/yii2-widget-activeform/blob/master/CHANGE.md) for details.
 
 ## Demo
 


### PR DESCRIPTION
#75 : closure as fieldConfig accepted also
#76: formConfig settings can be changed between field calls. The CSS init has been moved from Form to Field class. 'labelSpan' and 'deviceSize' can be defined as option in the field call individually also.

As part of #76 ActiveField is more compatible with Yii/bootstrap/ActiveField. Template has been enhanced with {beginWrapper}, {endWrapper}, {beginLabel}, {labelTitle} and {endlabel} tags. Current tags are still working.

FieldConfig (field option) has been extended with array 'horizontalCssClass['wrapper' | 'label' | 'offset' | 'error' | 'hint']'. These CSS classes are added to 'labelSpan' generated, if there is no 'col-' tag otherwise it overrides 'labelSpan' generated tag.

@kartik-v : I have commented a lot of changes in the code. Also removed methods are commented out. Please check it and remove my comments. Probably you could do things more easy or elegant. Please change it if you want to.