### PR TITLE
Don't render additional container if the content is empty

### DIFF
--- a/ActiveField.php
+++ b/ActiveField.php
@@ -410,6 +410,9 @@ class ActiveField extends YiiActiveField
         $html = "";
         foreach ($addon as $addonItem) {
             $content = ArrayHelper::getValue($addonItem, 'content', '');
+            // Avoid rendering the container if the content is null
+            if (empty($content))
+                continue;
             $options = ArrayHelper::getValue($addonItem, 'options', []);
             $suffix = ArrayHelper::getValue($addonItem, 'asButton', false) ? 'btn' : 'addon';
             Html::addCssClass($options, 'input-group-' . $suffix);


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
When using `addon` option, don't render the container if the content is empty. This avoid having to check it before rendering.
