### PR TITLE
Add enableContainer property

### DIFF
--- a/ActiveField.php
+++ b/ActiveField.php
@@ -327,6 +327,11 @@ class ActiveField extends YiiActiveField
      */
     public $horizontalCssClasses;
 
+     /**
+     * @var boolean whether the current input should include a surrounding div container
+     */
+    public $enableContainer = true;
+
     /**
      * @var boolean whether the input is to be offset (like for checkbox or radio).
      */
@@ -423,10 +428,36 @@ class ActiveField extends YiiActiveField
      */
     public function begin()
     {
-        if ($this->_hasFeedback) {
-            Html::addCssClass($this->options, 'has-feedback');
+        if ($this->enableContainer) {
+            if ($this->_hasFeedback) {
+                Html::addCssClass($this->options, 'has-feedback');
+            }
+            return parent::begin();
         }
-        return parent::begin();
+        
+        return "";
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function end()
+    {
+        if ($this->enableContainer) {
+            return parent::begin();
+        }
+        
+        return "";
+    }
+    
+    /**
+     * Switch to enable methtod chaining on setting container preference.
+     * Refer to $enableContainer property on more information.
+     */
+    public function enableContainer($withContainer=true)
+    {
+        $this->enableContainer = $withContainer;
+        return $this;
     }
 
     /**

--- a/ActiveField.php
+++ b/ActiveField.php
@@ -1327,7 +1327,10 @@ class ActiveField extends YiiActiveField
         Html::addCssClass($group, 'input-group');
         $contentBefore = ArrayHelper::getValue($addon, 'contentBefore', '');
         $contentAfter = ArrayHelper::getValue($addon, 'contentAfter', '');
-        $content = Html::tag('div', $contentBefore . $content . $contentAfter, $group);
+        $content = $contentBefore . $content . $contentAfter;
+        if ($this->withContainer) {
+            $content = Html::tag('div', $content, $group);
+        }
         return $content;
     }
 


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The current implementation, always by default outputs a div container surrounding the control. This would create display issues when using $field->$control in addon property. By removing surrounding container, there would be no display issues anymore when using $field-> as an addon.
