### PR TITLE
Fix undefined index errors.

### DIFF
--- a/ActiveForm.php
+++ b/ActiveForm.php
@@ -187,8 +187,8 @@ class ActiveForm extends YiiActiveForm
     public function getFormLayoutStyle()
     {
         $config = $this->formConfig;
-        $span = $config['labelSpan'];
-        $size = $config['deviceSize'];
+        $span = isset($config['labelSpan']) ? $config['labelSpan'] : null;
+        $size = isset($config['deviceSize']) ? $config['deviceSize'] : null;
         $labelCss = $inputCss = $offsetCss = ActiveField::NOT_SET;
         $iSpan = intval($span);
         if ($span != ActiveField::NOT_SET && $iSpan > 0) {


### PR DESCRIPTION
Since `$formConfig` is public the `getFormLayoutStyle()` function should not trust that certain keys are defined.

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-widget-activeform/blob/master/CHANGE.md)):

- Fix undefined index error in `getFormLayoutStyle()`
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.