### PR TITLE
fix {beginWrapper} in sub-attributes

### DIFF
--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -1142,8 +1142,6 @@ class ActiveField extends YiiActiveField
         }
         if ($this->skipFormLayout) {
             $this->mergeSettings($showLabels, $showErrors);
-            $this->parts['{beginWrapper}'] = '';
-            $this->parts['{endWrapper}'] = '';
             $this->parts['{beginLabel}'] = '';
             $this->parts['{labelTitle}'] = '';
             $this->parts['{endLabel}'] = '';

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -1142,6 +1142,8 @@ class ActiveField extends YiiActiveField
         }
         if ($this->skipFormLayout) {
             $this->mergeSettings($showLabels, $showErrors);
+            $this->parts['{beginWrapper}'] = '';
+            $this->parts['{endWrapper}'] = '';
             $this->parts['{beginLabel}'] = '';
             $this->parts['{labelTitle}'] = '';
             $this->parts['{endLabel}'] = '';


### PR DESCRIPTION
this PR fill {beginWrapper} & {endWrapper} with empty string. prevent it displayed in sub-attributes