### PR TITLE
Fixed type hinting error.

### DIFF
--- a/src/ActiveForm.php
+++ b/src/ActiveForm.php
@@ -42,7 +42,7 @@ use yii\widgets\ActiveForm as YiiActiveForm;
  * ]);
  * ~~~
  *
- * @method ActiveField field(Model $model, \string $attribute, array $options = [])
+ * @method ActiveField field(Model $model, string $attribute, array $options = [])
  * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @since  1.0
  */


### PR DESCRIPTION
#68  Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-widget-activeform/blob/master/CHANGE.md)):

- Fixed type hinting error: Parameter $attribute of method kartik\form\ActiveForm::field() expects string, string given.

## Related Issues
If this is related to an existing ticket, include a link to it as well.